### PR TITLE
Fix/uppsf 1100 missing metadata serialization

### DIFF
--- a/service/concept/concordance_test.go
+++ b/service/concept/concordance_test.go
@@ -142,7 +142,7 @@ func TestConcordanceApiService_GetConceptsErrorOnNewRequest(t *testing.T) {
 	concepts, err := concordanceApiService.GetConcepts("tid_test", []string{sampleID})
 
 	expect.Error(err)
-	expect.Equal("parse ://concordances: missing protocol scheme", err.Error())
+	expect.Equal("parse \"://concordances\": missing protocol scheme", err.Error())
 	expect.Nil(concepts)
 }
 
@@ -241,7 +241,7 @@ func TestConcordanceApiService_CheckHealthErrorOnNewRequest(t *testing.T) {
 	check, err := concordanceApiService.HealthCheck()
 	expect.Error(err)
 	expect.Empty(check)
-	expect.Equal("parse ://__gtg: missing protocol scheme", err.Error())
+	expect.Equal("parse \"://__gtg\": missing protocol scheme", err.Error())
 }
 
 func TestConcordanceApiService_CheckHealthErrorOnRequestDo(t *testing.T) {

--- a/service/message_handler.go
+++ b/service/message_handler.go
@@ -17,19 +17,23 @@ import (
 )
 
 const (
-	syntheticRequestPrefix   = "SYNTHETIC-REQ-MON"
-	transactionIDHeader      = "X-Request-Id"
-	blogsAuthority           = "http://api.ft.com/system/FT-LABS-WP"
-	articleAuthority         = "http://api.ft.com/system/FTCOM-METHODE"
-	videoAuthority           = "http://api.ft.com/system/NEXT-VIDEO-EDITOR"
-	originHeader             = "Origin-System-Id"
-	methodeOrigin            = "methode-web-pub"
-	wordpressOrigin          = "wordpress"
-	videoOrigin              = "next-video-editor"
-	pacOrigin                = "http://cmdb.ft.com/systems/pac"
-	contentTypeHeader        = "Content-Type"
-	audioContentTypeHeader   = "ft-upp-audio"
-	articleContentTypeHeader = "ft-upp-article"
+	syntheticRequestPrefix      = "SYNTHETIC-REQ-MON"
+	transactionIDHeader         = "X-Request-Id"
+	blogsAuthority              = "http://api.ft.com/system/FT-LABS-WP"
+	methodeArticleAuthority     = "http://api.ft.com/system/FTCOM-METHODE"
+	genericArticleAuthoriy      = "http://api.ft.com/system/cct"
+	genericSparkArticleAuthoriy = "http://api.ft.com/system/spark"
+	videoAuthority              = "http://api.ft.com/system/NEXT-VIDEO-EDITOR"
+	originHeader                = "Origin-System-Id"
+	cctOrigin                   = "cct"
+	sparkOrigin                 = "spark"
+	methodeOrigin               = "methode-web-pub"
+	wordpressOrigin             = "wordpress"
+	videoOrigin                 = "next-video-editor"
+	pacOrigin                   = "http://cmdb.ft.com/systems/pac"
+	contentTypeHeader           = "Content-Type"
+	audioContentTypeHeader      = "ft-upp-audio"
+	articleContentTypeHeader    = "ft-upp-article"
 )
 
 // Empty type added for older content. Placeholders - which are subject of exclusion - have type Content.
@@ -127,7 +131,7 @@ func (handler *MessageHandler) handleMessage(msg consumer.Message) {
 	logger.WithTransactionID(tid).WithUUID(uuid).Info("Processing combined post publication event")
 
 	contentType := extractContentTypeFromMsg(msg, combinedPostPublicationEvent)
-	if contentType == "" && msg.Headers[originHeader] != pacOrigin{
+	if contentType == "" && msg.Headers[originHeader] != pacOrigin {
 		logger.WithTransactionID(tid).WithUUID(uuid).Error("Failed to index content. Could not infer type of content")
 		return
 	}
@@ -159,33 +163,46 @@ func (handler *MessageHandler) handleMessage(msg consumer.Message) {
 }
 
 func extractContentTypeFromMsg(msg consumer.Message, event content.EnrichedContent) string {
-	var contentType string
+
 	typeHeader := msg.Headers[contentTypeHeader]
 	if strings.Contains(typeHeader, audioContentTypeHeader) {
-		contentType = AudioType
-	} else if strings.Contains(typeHeader, articleContentTypeHeader) {
-		contentType = ArticleType
-	} else {
-		for _, identifier := range event.Content.Identifiers {
-			if strings.HasPrefix(identifier.Authority, blogsAuthority) {
-				contentType = BlogType
-			} else if strings.HasPrefix(identifier.Authority, articleAuthority) {
-				contentType = ArticleType
-			} else if strings.HasPrefix(identifier.Authority, videoAuthority) {
-				contentType = VideoType
-			}
+		return AudioType
+	}
+	if strings.Contains(typeHeader, articleContentTypeHeader) {
+		return ArticleType
+	}
+	var contentType string
+
+	for _, identifier := range event.Content.Identifiers {
+		if strings.HasPrefix(identifier.Authority, blogsAuthority) {
+			contentType = BlogType
+		} else if strings.HasPrefix(identifier.Authority, methodeArticleAuthority) {
+			contentType = ArticleType
+		} else if strings.HasPrefix(identifier.Authority, videoAuthority) {
+			contentType = VideoType
+		} else if strings.HasPrefix(identifier.Authority, genericArticleAuthoriy) {
+			contentType = ArticleType
+		} else if strings.HasPrefix(identifier.Authority, genericSparkArticleAuthoriy) {
+			contentType = ArticleType
+		}
+	}
+	if contentType != "" {
+		return contentType
+	}
+
+	msgOrigin := msg.Headers[originHeader]
+	originMap := map[string]string{
+		methodeOrigin:   ArticleType,
+		cctOrigin:       ArticleType,
+		sparkOrigin:     ArticleType,
+		wordpressOrigin: BlogType,
+		videoOrigin:     VideoType,
+	}
+	for origin, contentType := range originMap {
+		if strings.Contains(msgOrigin, origin) {
+			return contentType
 		}
 	}
 
-	if contentType == "" {
-		origin := msg.Headers[originHeader]
-		if strings.Contains(origin, methodeOrigin) {
-			contentType = ArticleType
-		} else if strings.Contains(origin, wordpressOrigin) {
-			contentType = BlogType
-		} else if strings.Contains(origin, videoOrigin) {
-			contentType = VideoType
-		}
-	}
-	return contentType
+	return ""
 }

--- a/service/message_handler_test.go
+++ b/service/message_handler_test.go
@@ -475,6 +475,40 @@ func TestHandlePACMessage(t *testing.T) {
 	serviceMock.AssertNotCalled(t, "DeleteData", mock.Anything, mock.Anything)
 }
 
+func TestHandlePACMessageWithOldSparkContent(t *testing.T) {
+
+	input, err := modifyTestInputAuthority("cct")
+	assert.NoError(t, err, "Unexpected error")
+
+	serviceMock := &esServiceMock{}
+	serviceMock.On("WriteData", "FTCom", "aae9611e-f66c-4fe4-a6c6-2e2bdea69060", mock.Anything).Return(&elastic.IndexResult{}, nil)
+	concordanceApiMock := new(concordanceApiMock)
+	concordanceApiMock.On("GetConcepts", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(map[string]concept.ConceptModel{}, nil)
+
+	handler := MessageHandler{esService: serviceMock, ConceptGetter: concordanceApiMock}
+	handler.handleMessage(consumer.Message{Body: input, Headers: map[string]string{"Origin-System-Id": "http://cmdb.ft.com/systems/pac"}})
+
+	serviceMock.AssertExpectations(t)
+	concordanceApiMock.AssertExpectations(t)
+}
+
+func TestHandlePACMessageWithSparkContent(t *testing.T) {
+
+	input, err := modifyTestInputAuthority("spark")
+	assert.NoError(t, err, "Unexpected error")
+
+	serviceMock := &esServiceMock{}
+	serviceMock.On("WriteData", "FTCom", "aae9611e-f66c-4fe4-a6c6-2e2bdea69060", mock.Anything).Return(&elastic.IndexResult{}, nil)
+	concordanceApiMock := new(concordanceApiMock)
+	concordanceApiMock.On("GetConcepts", mock.AnythingOfType("string"), mock.AnythingOfType("[]string")).Return(map[string]concept.ConceptModel{}, nil)
+
+	handler := MessageHandler{esService: serviceMock, ConceptGetter: concordanceApiMock}
+	handler.handleMessage(consumer.Message{Body: input, Headers: map[string]string{"Origin-System-Id": "http://cmdb.ft.com/systems/pac"}})
+
+	serviceMock.AssertExpectations(t)
+	concordanceApiMock.AssertExpectations(t)
+}
+
 func modifyTestInputAuthority(replacement string) (string, error) {
 
 	inputJSON, err := ioutil.ReadFile("testdata/exampleEnrichedContentModel.json")


### PR DESCRIPTION
**Bug**: The service received a valid kafka message with both `content` and `metadata` in it, but discarded it, because it couldn't deduce the type of the content in it.
The bug is evident only for Spark content and only when the origin of the kafka message is `http://cmdb.ft.com/systems/pac`.

**The reason**:`content-rw-elasticsearch` tries to deduce content type based on message headers or authority identifiers in the `content` itself. In our case the headers were PAC headers and the identifiers were of type which the service did not understand (`cct`, `spark`). So it did not report an error, but also it did discard the message.

**Fix**: Added checks for Spark authority identifiers. Simplified the code a little.

 