### PR TITLE
Feature/cph 282 migrate to iamroles

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,20 +74,21 @@ make build-readonly
 ```
 
 ```txt
-Options:
-      --app-system-code                System Code of the application (env $APP_SYSTEM_CODE) (default "content-rw-elasticsearch")
-      --app-name                       Application name (env $APP_NAME) (default "content-rw-elasticsearch")
-      --port                           Port to listen on (env $APP_PORT) (default "8080")
-      --logLevel                       Logging level (DEBUG, INFO, WARN, ERROR) (env $LOG_LEVEL) (default "INFO")
-      --aws-access-key                 AWS ACCES KEY (env $AWS_ACCESS_KEY_ID)
-      --aws-secret-access-key          AWS SECRET ACCES KEY (env $AWS_SECRET_ACCESS_KEY)
-      --elasticsearch-sapi-endpoint    AES endpoint (env $ELASTICSEARCH_SAPI_ENDPOINT) (default "http://localhost:9200")
-      --index-name                     The name of the elaticsearch index (env $ELASTICSEARCH_SAPI_INDEX) (default "ft")
-      --kafka-address                  Addresses used by the consumer to connect to Kafka (env $KAFKA_ADDR) (default "kafka:9092")
-      --kafka-consumer-group           Group used to read the messages from the queue (env $KAFKA_CONSUMER_GROUP) (default "content-rw-elasticsearch")
-      --kafka-topic                    The topic to read the messages from (env $KAFKA_TOPIC) (default "CombinedPostPublicationEvents")
-      --public-concordances-endpoint   Endpoint to concord ids with (env $PUBLIC_CONCORDANCES_ENDPOINT) (default "http://public-concordances-api:8080")
-      --base-api-url                   Base API URL (env $BASE_API_URL) (default "https://api.ft.com/")
+Options:                                    
+      --app-system-code                     System Code of the application (env $APP_SYSTEM_CODE) (default "content-rw-elasticsearch")
+      --app-name                            Application name (env $APP_NAME) (default "content-rw-elasticsearch")
+      --port                                Port to listen on (env $APP_PORT) (default "8080")
+      --logLevel                            Logging level (DEBUG, INFO, WARN, ERROR) (env $LOG_LEVEL) (default "INFO")
+      --elasticsearch-sapi-endpoint         AES endpoint (env $ELASTICSEARCH_SAPI_ENDPOINT) (default "http://localhost:9200")
+      --elasticsearch-region                AES region (env $ELASTICSEARCH_REGION) (default "local")
+      --index-name                          The name of the elasticsearch index (env $ELASTICSEARCH_SAPI_INDEX) (default "ft")
+      --kafka-address                       Addresses used by the queue consumer to connect to Kafka (env $KAFKA_ADDR) (default "kafka:9092")
+      --kafka-consumer-group                Group used to read the messages from the queue (env $KAFKA_CONSUMER_GROUP) (default "content-rw-elasticsearch")
+      --kafka-topic                         The topic to read the messages from (env $KAFKA_TOPIC) (default "CombinedPostPublicationEvents")
+      --kafka-topic-offset-fetch-interval   Interval (in minutes) between each offset fetching request (env $KAFKA_TOPIC_OFFSET_FETCH_INTERVAL) (default 0)
+      --kafka-topic-lag-tolerance           Lag tolerance (in number of messages) used for monitoring the Kafka consumer (env $KAFKA_TOPIC_LAG_TOLERANCE) (default 0)
+      --public-concordances-endpoint        Endpoint to concord ids with (env $PUBLIC_CONCORDANCES_ENDPOINT) (default "http://public-concordances-api:8080")
+      --base-api-url                        Base API URL (env $BASE_API_URL) (default "https://api.ft.com/")
 ```
 
 ## Build and deployment

--- a/cmd/content-rw-elasticsearch/main.go
+++ b/cmd/content-rw-elasticsearch/main.go
@@ -18,6 +18,8 @@ import (
 	cli "github.com/jawher/mow.cli"
 )
 
+const defaultESTestingEndpoint = "http://localhost:9000"
+
 func main() {
 	app := cli.App(config.AppName, config.AppDescription)
 
@@ -100,22 +102,30 @@ func main() {
 
 	log := logger.NewUPPLogger(*appSystemCode, *logLevel)
 	log.Info("[Startup] Application is starting")
-	awsSession, sessionErr := session.NewSession()
-	if sessionErr != nil {
-		log.WithError(sessionErr).Fatal("Failed to initialize AWS session")
-	}
-	credValues, err := awsSession.Config.Credentials.Get()
-	if err != nil {
-		log.WithError(err).Fatal("Failed to obtain AWS credentials values")
-	}
-	log.Infof("Obtaining AWS credentials by using [%s] as provider", credValues.ProviderName)
 
 	app.Action = func() {
 		accessConfig := es.AccessConfig{
-			AccessKey:    credValues.AccessKeyID,
-			SecretKey:    credValues.SecretAccessKey,
-			SessionToken: credValues.SessionToken,
-			Endpoint:     *esEndpoint,
+			Endpoint: *esEndpoint,
+		}
+
+		if *esEndpoint != defaultESTestingEndpoint {
+			log.Info("Trying to get session credentials")
+			awsSession, sessionErr := session.NewSession()
+			if sessionErr != nil {
+				log.WithError(sessionErr).Fatal("Failed to initialize AWS session")
+			}
+			credValues, err := awsSession.Config.Credentials.Get()
+			if err != nil {
+				log.WithError(err).Fatal("Failed to obtain AWS credentials values")
+			}
+			log.Infof("Obtaining AWS credentials by using [%s] as provider", credValues.ProviderName)
+
+			accessConfig = es.AccessConfig{
+				AccessKey:    credValues.AccessKeyID,
+				SecretKey:    credValues.SecretAccessKey,
+				SessionToken: credValues.SessionToken,
+				Endpoint:     *esEndpoint,
+			}
 		}
 
 		httpClient := pkghttp.NewHTTPClient()
@@ -160,7 +170,7 @@ func main() {
 
 		handler.Stop()
 	}
-	err = app.Run(os.Args)
+	err := app.Run(os.Args)
 	if err != nil {
 		log.WithError(err).WithTime(time.Now()).Fatal("App could not start")
 		return

--- a/cmd/content-rw-elasticsearch/main.go
+++ b/cmd/content-rw-elasticsearch/main.go
@@ -112,9 +112,9 @@ func main() {
 
 	app.Action = func() {
 		accessConfig := es.AccessConfig{
-			AwsCreds: credentials.AnonymousCredentials,
+			AwsCreds: credentials.AnonymousCredentials, // placeholder credentials to escape nil pointer error
 			Endpoint: *esEndpoint,
-			Region:   *esRegion,
+			Region:   *esRegion, // for the dredd tests to pass, we use the `local` region to specify that we don't want to sign requests
 		}
 
 		if *esEndpoint != defaultESTestingEndpoint {

--- a/cmd/content-rw-elasticsearch/main.go
+++ b/cmd/content-rw-elasticsearch/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Financial-Times/content-rw-elasticsearch/v4/pkg/message"
 	"github.com/Financial-Times/go-logger/v2"
 	"github.com/Financial-Times/kafka-client-go/v3"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	cli "github.com/jawher/mow.cli"
 )
@@ -111,7 +112,9 @@ func main() {
 
 	app.Action = func() {
 		accessConfig := es.AccessConfig{
+			AwsCreds: credentials.AnonymousCredentials,
 			Endpoint: *esEndpoint,
+			Region:   *esRegion,
 		}
 
 		if *esEndpoint != defaultESTestingEndpoint {

--- a/cmd/content-rw-elasticsearch/main.go
+++ b/cmd/content-rw-elasticsearch/main.go
@@ -53,6 +53,12 @@ func main() {
 		Desc:   "AES endpoint",
 		EnvVar: "ELASTICSEARCH_SAPI_ENDPOINT",
 	})
+	esRegion := app.String(cli.StringOpt{
+		Name:   "elasticsearch-region",
+		Value:  "local",
+		Desc:   "AES region",
+		EnvVar: "ELASTICSEARCH_REGION",
+	})
 	indexName := app.String(cli.StringOpt{
 		Name:   "index-name",
 		Value:  "ft",
@@ -118,13 +124,13 @@ func main() {
 			if err != nil {
 				log.WithError(err).Fatal("Failed to obtain AWS credentials values")
 			}
+			awsCreds := awsSession.Config.Credentials
 			log.Infof("Obtaining AWS credentials by using [%s] as provider", credValues.ProviderName)
 
 			accessConfig = es.AccessConfig{
-				AccessKey:    credValues.AccessKeyID,
-				SecretKey:    credValues.SecretAccessKey,
-				SessionToken: credValues.SessionToken,
-				Endpoint:     *esEndpoint,
+				AwsCreds: awsCreds,
+				Endpoint: *esEndpoint,
+				Region:   *esRegion,
 			}
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Financial-Times/kafka-client-go/v3 v3.0.5
 	github.com/Financial-Times/service-status-go v0.0.0-20160323111542-3f5199736a3d
 	github.com/Financial-Times/transactionid-utils-go v0.2.0
+	github.com/aws/aws-sdk-go v1.44.105
 	github.com/gorilla/mux v1.8.0
 	github.com/jawher/mow.cli v1.0.4
 	github.com/olivere/elastic/v7 v7.0.29
@@ -35,6 +36,7 @@ require (
 	github.com/jcmturner/gofork v1.0.0 // indirect
 	github.com/jcmturner/gokrb5/v8 v8.4.2 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.15.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,11 @@ require (
 	github.com/Financial-Times/kafka-client-go/v3 v3.0.5
 	github.com/Financial-Times/service-status-go v0.0.0-20160323111542-3f5199736a3d
 	github.com/Financial-Times/transactionid-utils-go v0.2.0
-	github.com/aws/aws-sdk-go v1.44.105
+	github.com/aws/aws-sdk-go v1.44.83
 	github.com/gorilla/mux v1.8.0
 	github.com/jawher/mow.cli v1.0.4
 	github.com/olivere/elastic/v7 v7.0.29
 	github.com/pborman/uuid v0.0.0-20170612153648-e790cca94e6c
-	github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -64,10 +64,7 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-<<<<<<< HEAD
 github.com/aws/aws-sdk-go v1.40.43/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-=======
->>>>>>> 4111b6c (Use AWS session for obtaining credentials for url signing)
 github.com/aws/aws-sdk-go v1.44.105 h1:UUwoD1PRKIj3ltrDUYTDQj5fOTK3XsnqolLpRTMmSEM=
 github.com/aws/aws-sdk-go v1.44.105/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -247,11 +244,8 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-<<<<<<< HEAD
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-=======
->>>>>>> 4111b6c (Use AWS session for obtaining credentials for url signing)
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -307,10 +301,7 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-<<<<<<< HEAD
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-=======
->>>>>>> 4111b6c (Use AWS session for obtaining credentials for url signing)
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.40.43/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.44.105 h1:UUwoD1PRKIj3ltrDUYTDQj5fOTK3XsnqolLpRTMmSEM=
+github.com/aws/aws-sdk-go v1.44.105/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -238,7 +240,9 @@ github.com/jcmturner/gokrb5/v8 v8.4.2 h1:6ZIM6b/JJN0X8UM43ZOM6Z4SJzla+a/u7scXFJz
 github.com/jcmturner/gokrb5/v8 v8.4.2/go.mod h1:sb+Xq/fTY5yktf/VxLsE3wlfPqQjp0aWNYyvBVK62bc=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -460,6 +464,7 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.40.43/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.44.83 h1:7+Rtc2Eio6EKUNoZeMV/IVxzVrY5oBQcNPtCcgIHYJA=
+github.com/aws/aws-sdk-go v1.44.83/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.105 h1:UUwoD1PRKIj3ltrDUYTDQj5fOTK3XsnqolLpRTMmSEM=
 github.com/aws/aws-sdk-go v1.44.105/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -323,11 +325,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartystreets/assertions v1.1.1 h1:T/YLemO5Yp7KPzS+lVtu+WsHn8yoSwTfItdAd1r3cck=
 github.com/smartystreets/assertions v1.1.1/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
-github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9 h1:hp2CYQUINdZMHdvTdXtPOY2ainKl4IoMcpAXEf2xj3Q=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
-github.com/smartystreets/gunit v1.4.2 h1:tyWYZffdPhQPfK5VsMQXfauwnJkqg7Tv5DLuQVYxq3Q=
 github.com/smartystreets/gunit v1.4.2/go.mod h1:ZjM1ozSIMJlAz/ay4SG8PeKF00ckUp+zMHZXV9/bvak=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=

--- a/go.sum
+++ b/go.sum
@@ -64,7 +64,10 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+<<<<<<< HEAD
 github.com/aws/aws-sdk-go v1.40.43/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+=======
+>>>>>>> 4111b6c (Use AWS session for obtaining credentials for url signing)
 github.com/aws/aws-sdk-go v1.44.105 h1:UUwoD1PRKIj3ltrDUYTDQj5fOTK3XsnqolLpRTMmSEM=
 github.com/aws/aws-sdk-go v1.44.105/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -244,8 +247,11 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+<<<<<<< HEAD
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+=======
+>>>>>>> 4111b6c (Use AWS session for obtaining credentials for url signing)
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -301,7 +307,10 @@ github.com/pelletier/go-toml v1.9.4/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+<<<<<<< HEAD
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+=======
+>>>>>>> 4111b6c (Use AWS session for obtaining credentials for url signing)
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/helm/content-rw-elasticsearch/templates/deployment.yaml
+++ b/helm/content-rw-elasticsearch/templates/deployment.yaml
@@ -39,6 +39,11 @@ spec:
             configMapKeyRef:
               name: global-config
               key: aws.content.elasticsearch.v2.endpoint
+        - name: ELASTICSEARCH_REGION
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: aws.region
         - name: ELASTICSEARCH_SAPI_INDEX
           value: "{{ .Values.env.ELASTICSEARCH_SAPI_INDEX }}"
         - name: KAFKA_CONSUMER_GROUP

--- a/helm/content-rw-elasticsearch/templates/deployment.yaml
+++ b/helm/content-rw-elasticsearch/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
                 values:
                 - {{ .Values.service.name }}
             topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: {{ .Values.serviceAccountName }}
       containers:
       - name: {{ .Values.service.name }}
         image: "{{ .Values.image.repository }}:{{ .Chart.Version }}"
@@ -53,16 +54,6 @@ spec:
             configMapKeyRef:
               name: global-config
               key: msk.kafka.broker.url
-        - name: AWS_ACCESS_KEY_ID
-          valueFrom:
-            secretKeyRef:
-              name: global-secrets
-              key: aws.access_key_id
-        - name: AWS_SECRET_ACCESS_KEY
-          valueFrom:
-            secretKeyRef:
-              name: global-secrets
-              key: aws.secret_access_key
         - name: PUBLIC_CONCORDANCES_ENDPOINT
           value: "{{ .Values.env.PUBLIC_CONCORDANCES_ENDPOINT }}"
         - name: "BASE_API_URL"

--- a/helm/content-rw-elasticsearch/values.yaml
+++ b/helm/content-rw-elasticsearch/values.yaml
@@ -18,3 +18,4 @@ env:
   KAFKA_TOPIC: ""
   PUBLIC_CONCORDANCES_ENDPOINT: ""
   ELASTICSEARCH_SAPI_INDEX: "ft-v1"
+serviceAccountName: eksctl-content-rw-elasticsearch-serviceaccount

--- a/pkg/es/client.go
+++ b/pkg/es/client.go
@@ -17,9 +17,10 @@ type Client interface {
 }
 
 type AccessConfig struct {
-	AccessKey string
-	SecretKey string
-	Endpoint  string
+	AccessKey    string
+	SecretKey    string
+	SessionToken string
+	Endpoint     string
 }
 
 type AWSSigningTransport struct {
@@ -37,6 +38,7 @@ func NewClient(config AccessConfig, c *http.Client, log *logger.UPPLogger) (Clie
 		Credentials: awsauth.Credentials{
 			AccessKeyID:     config.AccessKey,
 			SecretAccessKey: config.SecretKey,
+			SecurityToken:   config.SessionToken,
 		},
 		HTTPClient: c,
 	}

--- a/pkg/es/client.go
+++ b/pkg/es/client.go
@@ -35,6 +35,7 @@ type AWSSigningTransport struct {
 
 // RoundTrip implementation
 func (a AWSSigningTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// If the region is local that means that we probably want to run dredd tests, so our requests won't get signed!
 	if a.Region == "local" {
 		return a.HTTPClient.Do(req)
 	}

--- a/pkg/es/client.go
+++ b/pkg/es/client.go
@@ -35,6 +35,10 @@ type AWSSigningTransport struct {
 
 // RoundTrip implementation
 func (a AWSSigningTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if a.Region == "local" {
+		return a.HTTPClient.Do(req)
+	}
+
 	signer := awsSigner.NewSigner(a.Credentials)
 	if req.Body != nil {
 		b, err := io.ReadAll(req.Body)

--- a/pkg/es/client.go
+++ b/pkg/es/client.go
@@ -1,11 +1,16 @@
 package es
 
 import (
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/Financial-Times/go-logger/v2"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	awsSigner "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/olivere/elastic/v7"
-	awsauth "github.com/smartystreets/go-aws-auth"
 )
 
 type Client interface {
@@ -17,30 +22,46 @@ type Client interface {
 }
 
 type AccessConfig struct {
-	AccessKey    string
-	SecretKey    string
-	SessionToken string
-	Endpoint     string
+	AwsCreds *credentials.Credentials
+	Endpoint string
+	Region   string
 }
 
 type AWSSigningTransport struct {
 	HTTPClient  *http.Client
-	Credentials awsauth.Credentials
+	Credentials *credentials.Credentials
+	Region      string
 }
 
 // RoundTrip implementation
 func (a AWSSigningTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return a.HTTPClient.Do(awsauth.Sign4(req, a.Credentials))
+	signer := awsSigner.NewSigner(a.Credentials)
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read request body with error: %w", err)
+		}
+		body := strings.NewReader(string(b))
+		defer req.Body.Close()
+		_, err = signer.Sign(req, body, "es", a.Region, time.Now())
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign request: %w", err)
+		}
+	} else {
+		_, err := signer.Sign(req, nil, "es", a.Region, time.Now())
+		if err != nil {
+			return nil, fmt.Errorf("failed to sign request: %w", err)
+		}
+	}
+
+	return a.HTTPClient.Do(req)
 }
 
 func NewClient(config AccessConfig, c *http.Client, log *logger.UPPLogger) (Client, error) {
 	signingTransport := AWSSigningTransport{
-		Credentials: awsauth.Credentials{
-			AccessKeyID:     config.AccessKey,
-			SecretAccessKey: config.SecretKey,
-			SecurityToken:   config.SessionToken,
-		},
-		HTTPClient: c,
+		Credentials: config.AwsCreds,
+		HTTPClient:  c,
+		Region:      config.Region,
 	}
 	signingClient := &http.Client{Transport: http.RoundTripper(signingTransport)}
 

--- a/pkg/message/message_handler_test.go
+++ b/pkg/message/message_handler_test.go
@@ -18,6 +18,7 @@ import (
 	testdata "github.com/Financial-Times/content-rw-elasticsearch/v4/test"
 	"github.com/Financial-Times/go-logger/v2"
 	"github.com/Financial-Times/kafka-client-go/v3"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/olivere/elastic/v7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -128,9 +129,8 @@ func mockMessageHandler(esClient ESClient, mocks ...interface{}) (es.AccessConfi
 	uppLogger := logger.NewUPPLogger(config.AppName, config.AppDefaultLogLevel)
 
 	accessConfig := es.AccessConfig{
-		AccessKey: "key",
-		SecretKey: "secret",
-		Endpoint:  "endpoint",
+		AwsCreds: &credentials.Credentials{},
+		Endpoint: "endpoint",
 	}
 
 	var concordanceAPI *concordanceAPIMock


### PR DESCRIPTION
# Description

## What

Migrate to IAM roles. Migrate github.com/smartystreets/go-aws-auth to github.com/aws/aws-sdk-go/aws/signer/v4 so we could automatically get new credentials for the session after they expire after an hour.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-3483)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
