### PR TITLE
Adding live event content type

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,10 +18,11 @@ const (
 	AppDescription     = "Content Read Writer for Elasticsearch"
 	AppDefaultLogLevel = "INFO"
 
-	ArticleType = "article"
-	VideoType   = "video"
-	BlogType    = "blog"
-	AudioType   = "audio"
+	ArticleType   = "article"
+	VideoType     = "video"
+	BlogType      = "blog"
+	AudioType     = "audio"
+	LiveEventType = "live-event"
 
 	PACOrigin = "http://cmdb.ft.com/systems/pac"
 

--- a/pkg/message/message_handler.go
+++ b/pkg/message/message_handler.go
@@ -18,12 +18,13 @@ import (
 )
 
 const (
-	syntheticRequestPrefix   = "SYNTHETIC-REQ-MON"
-	transactionIDHeader      = "X-Request-Id"
-	originHeader             = "Origin-System-Id"
-	contentTypeHeader        = "Content-Type"
-	audioContentTypeHeader   = "ft-upp-audio"
-	articleContentTypeHeader = "ft-upp-article"
+	syntheticRequestPrefix     = "SYNTHETIC-REQ-MON"
+	transactionIDHeader        = "X-Request-Id"
+	originHeader               = "Origin-System-Id"
+	contentTypeHeader          = "Content-Type"
+	audioContentTypeHeader     = "ft-upp-audio"
+	articleContentTypeHeader   = "ft-upp-article"
+	liveEventContentTypeHeader = "ft-upp-live-event"
 
 	contextTimeout = 10 * time.Second
 )
@@ -163,6 +164,10 @@ func (h *Handler) readContentType(msg kafka.FTMessage, event schema.EnrichedCont
 	if strings.Contains(typeHeader, articleContentTypeHeader) {
 		return config.ArticleType
 	}
+	if strings.Contains(typeHeader, liveEventContentTypeHeader) {
+		return config.LiveEventType
+	}
+
 	contentMetadata := h.mapper.Config.ContentMetadataMap
 	for _, identifier := range event.Content.Identifiers {
 		for _, t := range contentMetadata {


### PR DESCRIPTION
# Description

## What

Adding handling live event types instead of throwing an error on delete requests.

When a delete event for a Live Event is handled, the content type cannot be inferred from the metadata in the `readContentType` function, since live events do not have metadata still. 
When a normal publish event for a live event happens, it is handled correctly. 

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3663

## Anything, in particular, you'd like to highlight to reviewers



## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
