### PR TITLE
Point to Content.Publication; fix schema

### DIFF
--- a/pkg/message/message_handler.go
+++ b/pkg/message/message_handler.go
@@ -122,7 +122,7 @@ func (h *Handler) handleMessage(msg kafka.FTMessage) {
 
 	input := map[string]interface{}{
 		"payload": map[string]interface{}{
-			"publication": combinedPostPublicationEvent.Publication,
+			"publication": combinedPostPublicationEvent.Content.Publication,
 		},
 	}
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -96,7 +96,6 @@ type EnrichedContent struct {
 	ContentURI      string          `json:"contentUri"`
 	LastModified    string          `json:"lastModified"`
 	Deleted         bool            `json:"deleted"`
-	Publication     []string        `json:"publication,omitempty"`
 }
 
 type Content struct {
@@ -119,6 +118,7 @@ type Content struct {
 	Scoop              bool         `json:"scoop"`
 	CanBeSyndicated    *string      `json:"canBeSyndicated"`
 	CanBeDistributed   *string      `json:"canBeDistributed"`
+	Publication        []string     `json:"publication"`
 }
 
 type dataSource struct {


### PR DESCRIPTION
# Description

## What

The bug is around Content schema definition. We should add Publication to Content schema and remove it from the unnecessary place.

## Why

[UPPSF-5305](https://financialtimes.atlassian.net/browse/UPPSF-5305)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)


[UPPSF-5305]: https://financialtimes.atlassian.net/browse/UPPSF-5305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ